### PR TITLE
Pin uv until bug is fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12
 
-RUN pip install uv
+RUN pip install uv==0.4.9
 
 RUN apt-get update && apt-get install libaio1 graphviz -y
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Docker image used for the `lotus` GitLab CI pipeline testing phase.
 The image includes:
 
 * [Python 3.12](https://hub.docker.com/_/python)
-* [uv](https://github.com/astral-sh/uv) (package resolver)
+* [uv](https://github.com/astral-sh/uv) (package resolver) ***TEMPORARILY PINNED TO `uv==0.4.9`***
 * [Graphviz](https://packages.debian.org/bookworm/graphviz) (for building the documentation)
 * [Oracle Instant Client](https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html) (version 23.5)
 * [libaio1 library](https://packages.debian.org/bookworm/libaio1) (dependency of Instant Client)


### PR DESCRIPTION
This PR temporarily pins `uv` to version 0.4.9 until the `lotus` pipeline issue is diagnosed and resolved. 